### PR TITLE
Add support for Jecang BLE Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mqtt-bed
 
-MQTT control for Serta adjustable beds with Bluetooth, like the [Serta Motion Perfect III](https://www.serta.com/sites/ssb/serta.com/uploads/2016/adjustable-foundations/MotionPerfectIII_Manual_V004_04142016.pdf)
+MQTT control for Serta adjustable beds with Bluetooth, like the [Serta Motion Perfect III](https://www.serta.com/sites/ssb/serta.com/uploads/2016/adjustable-foundations/MotionPerfectIII_Manual_V004_04142016.pdf) And 'Glide' with the jiecang ble controller (Dream Motion app)
 
 Based upon code from https://github.com/danisla/iot-bed
 

--- a/config.py
+++ b/config.py
@@ -8,6 +8,9 @@ MQTT_SERVER = "127.0.0.1"
 MQTT_SERVER_PORT = 1883
 MQTT_TOPIC = "bed"
 
+# Bed controller type, supported values are "serta" and "jiecang"
+BED_TYPE = "serta"
+
 # Don't worry about these unless you want to
 MQTT_CHECKIN_TOPIC = "checkIn/bed"
 MQTT_CHECKIN_PAYLOAD = "OK"

--- a/controllers/jiecang.py
+++ b/controllers/jiecang.py
@@ -5,8 +5,8 @@ class jiecangBLEController:
     def __init__(self, addr):
         self.addr = addr
         self.commands = {
-            "Memory 1": "f1f10d01010f7e",
-            "Memory 2": "f1f10b01010d7e",
+            "Memory 1": "f1f10b01010d7e",
+            "Memory 2": "f1f10d01010f7e",
             "Flat": "f1f10801010a7e",
             "Zero G": "f1f1070101097e",
         }

--- a/controllers/jiecang.py
+++ b/controllers/jiecang.py
@@ -1,0 +1,27 @@
+
+import pygatt
+
+class jiecangBLEController:
+    def __init__(self, addr):
+        self.addr = addr
+        self.commands = {
+            "Memory 1": "f1f10d01010f7e",
+            "Memory 2": "f1f10b01010d7e",
+            "Flat": "f1f10801010a7e",
+            "Zero G": "f1f1070101097e",
+        }
+        self.adapter = pygatt.GATTToolBackend()
+
+    def sendCommand(self, name):
+        cmd = self.commands.get(name, None)
+        if cmd is None:
+            raise Exception("Command not found: " + str(name))
+        try:
+            self.adapter.start()
+            device = self.adapter.connect(self.addr)
+            res = device.char_write('0000ff01-0000-1000-8000-00805f9b34fb', bytes.fromhex(cmd), wait_for_response=False)
+        finally:
+            self.adapter.stop()
+        return res
+
+   

--- a/mqtt-bed.py
+++ b/mqtt-bed.py
@@ -5,6 +5,7 @@ import asyncio
 from contextlib import AsyncExitStack, asynccontextmanager
 from asyncio_mqtt import Client, MqttError
 
+from controllers.jiecang import jiecangBLEController
 from controllers.serta import sertaBLEController
 
 # mqtt-bed default config values. Set these in config.py yourself.
@@ -18,6 +19,7 @@ MQTT_CHECKIN_PAYLOAD = "OK"
 MQTT_ONLINE_PAYLOAD = "online"
 MQTT_QOS = 0
 DEBUG = 0
+BED_TYPE = "serta"
 
 from config import *
 
@@ -96,8 +98,13 @@ async def main():
 
     if ble_address is None:
         raise Exception("BLE_ADDRESS env not set")
-
-    ble = sertaBLEController(ble_address)
+    
+    if BED_TYPE == "serta":
+        ble = sertaBLEController(ble_address)
+    elif BED_TYPE == "jiecang":
+        ble = jiecangBLEController(ble_address)
+    else:
+        raise Exception("Unrecognised bed type: " + str(BED_TYPE))
 
     # Run the bed_loop indefinitely. Reconnect automatically
     # if the connection is lost.


### PR DESCRIPTION
This adds support for the 'glide' adjustable bed with jecang Bluetooth controller. Due to multiple types being supported, there is now bed type configuration variable in config.py with the supported values of "jecang" and "serta". 

Feel free to modify the readme as i did not word it too well.

Thanks!