### PR TITLE
initialize bed control for RF Eco BT

### DIFF
--- a/controllers/dewertokin.py
+++ b/controllers/dewertokin.py
@@ -103,6 +103,10 @@ class dewertokinBLEController:
                 print("Attempting to connect to bed.")
                 self.device = ble.Peripheral(deviceAddr=self.addr, addrType='random')
                 print("Connected to bed.")
+                print("Enabling bed control.")
+                self.device.readCharacteristic(0x001e)
+                self.device.readCharacteristic(0x0020)
+                print("Bed control enabled.")
                 return
             except:
                 pass


### PR DESCRIPTION
Hi,
I recently opened [this issue](https://github.com/dennyreiter/mqtt-bed/issues/4),
because my Okin Rf Eco BT could not controlled.

In order to have functional device.writeCharacteristic requests, initially 2 handlers need to be read from the device once.

This PR fixes the issue. :)