### PR TITLE
Added Home Assistant MQTT Discovery Payloads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 19.10b0 # Replace by any tag/version: https://github.com/psf/black/tags
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
     hooks:
-      - id: black
-        language_version: python3 # Should be a command that runs python3.9+
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.13
+    hooks:
+      - id: ruff  # Run the linter.
+        args: [ '--select I', '--fix' ]
+      - id: ruff-format  # Run the formatter.

--- a/README.md
+++ b/README.md
@@ -104,9 +104,17 @@ You can check the status of the service at any time by running `sudo systemctl s
 You can also view the live logs from this service at any time by running `sudo journalctl -u mqtt-bed.service -f`
 
 ## Home Assistant Integration
+
 The YAML used in Home Assistant to integrate your bed will vary by your installation and bed type, but you can find example YAML for in the `homeassistant-script.yaml` file in this repository.
 
 In addition, it is common to run the MQTT Broker service in your Home Assitant installation if you do not have a broker running already, in which case you can use the [official Mosquito broker addon](https://github.com/home-assistant/addons/blob/master/mosquitto/DOCS.md). Once you have your broker setup, you will want to fill in your Home Assistant information in the MQTT config section of the `config.yaml` file.
+
+### Automatic Discovery
+For an even more seamless integration with Home Assistant, this project supports MQTT Discovery, which allows certain bed controllers to be automatically recognized and configured in Home Assistant. This feature simplifies the setup process and reduces the need for manual YAML configuration.
+
+To enable MQTT Discovery, set the `MQTT_DISCOVERY` option to `true` in the `config.yaml` file.
+
+> Note: MQTT Discovery is currently only supported by the Linak controller.
 
 ## Trusting Bluetooth device on Linux
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ MQTT_PASSWORD: mqtt-pass
 MQTT_SERVER: 127.0.0.1
 MQTT_SERVER_PORT: 1883
 MQTT_TOPIC: bed
+MQTT_SSL: false
 
 # MQTT topics & payloads
 MQTT_BASE_TOPIC: bed

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,10 @@
 # The bluetooth address used by your bed
 BED_ADDRESS: "00:00:00:00:00:00"
 
+# Bed controller type, supported values are
+# "serta", "jiecang", "dewertokin", and "linak"
+BED_TYPE: serta
+
 # MQTT credentials
 MQTT_USERNAME: mqtt-user
 MQTT_PASSWORD: mqtt-pass
@@ -8,14 +12,16 @@ MQTT_SERVER: 127.0.0.1
 MQTT_SERVER_PORT: 1883
 MQTT_TOPIC: bed
 
-# Bed controller type, supported values are
-# "serta", "jiecang", "dewertokin", and "linak"
-BED_TYPE: serta
-
-# MQTT hearbeat parameters
-MQTT_CHECKIN_TOPIC: checkIn/bed
-MQTT_CHECKIN_PAYLOAD: OK
-MQTT_ONLINE_PAYLOAD: online
-MQTT_SHUTDOWN_PAYLOAD: shutdown
+# MQTT topics & payloads
+MQTT_BASE_TOPIC: bed
+MQTT_BED_NAME: Bed
+MQTT_AVAILABILITY_TOPIC: availability
+MQTT_AVAILABLE_PAYLOAD: online
+MQTT_NOT_AVAILABLE_PAYLOAD: offline
 MQTT_QOS: 0
 RECONNECT_INTERVAL: 3  # Seconds
+
+# MQTT Automatic Discovery with Home Assistant
+# Currently only works with the Linak controller
+# https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+MQTT_DISCOVERY: false

--- a/controllers/jiecang.py
+++ b/controllers/jiecang.py
@@ -1,9 +1,11 @@
-
 import pygatt
+
 
 class jiecangBLEController:
     def __init__(self, addr):
         self.addr = addr
+        self.manufacturer = "Jiecang"
+        self.model = "Glide"
         self.commands = {
             "Memory 1": "f1f10b01010d7e",
             "Memory 2": "f1f10d01010f7e",
@@ -12,16 +14,18 @@ class jiecangBLEController:
         }
         self.adapter = pygatt.GATTToolBackend()
 
-    def sendCommand(self, name):
+    def send_command(self, name):
         cmd = self.commands.get(name, None)
         if cmd is None:
             raise Exception("Command not found: " + str(name))
         try:
             self.adapter.start()
             device = self.adapter.connect(self.addr)
-            res = device.char_write('0000ff01-0000-1000-8000-00805f9b34fb', bytes.fromhex(cmd), wait_for_response=False)
+            res = device.char_write(
+                "0000ff01-0000-1000-8000-00805f9b34fb",
+                bytes.fromhex(cmd),
+                wait_for_response=False,
+            )
         finally:
             self.adapter.stop()
         return res
-
-   

--- a/controllers/linak.py
+++ b/controllers/linak.py
@@ -1,53 +1,68 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import bluepy.btle as ble
 import logging
 import time
+
+import bluepy.btle as ble
 
 
 class linakBLEController:
     def __init__(self, addr):
         self.logger = logging.getLogger(__name__)
-        self.charWriteInProgress = False
+        self.write_in_progress = False
         self.addr = addr
-        self.uuid = '99FA0002-338A-1024-8A49-009C0215F78A'
+        self.uuid = "99FA0002-338A-1024-8A49-009C0215F78A"
         self.commands = {
-            "Head Up": "0B00",
-            "Head Down": "0A00",
-            "Feet Up": "0900",
-            "Feet Down": "0800",
-            "Both Up": "0100",
-            "Both Down": "0000",
-            "Light": "9400",
-        }
-        self.connectBed(ble)
+            "head_up": "0B00",
+            "head_down": "0A00",
+            "feet_up": "0900",
+            "feet_down": "0800",
+            "both_up": "0100",
+            "both_down": "0000",
+            "light": "9400",
+        }  # A map of the MQTT payload string to BLE payload bytes
+        self.head_increment = 100 / 85  # Number of commands required
+        self.feet_increment = 100 / 60  # to go from 0% to 100%
 
-    def print_characteristics(self):
-        try:
-            for service in self.device.getServices():
-                for chara in service.getCharacteristics():
-                    self.logger.debug("Characteristic UUID: %s" % chara.uuid)
-                    self.logger.debug("Handle: 0x%04x" % chara.getHandle())
-                    properties = chara.propertiesToString()
-                    self.logger.debug("Properties: %s" % properties)
-                    self.logger.debug("----------------------------------------------------------")
-        except Exception as e:
-            self.logger.error("Error accessing characteristic: %s" % str(e))
+        # To keep track of "state" since the bed doesn't
+        self.head_position = 0
+        self.feet_position = 0
+        self.light_status = False
+
+        # Required fields for MQTT Discovery
+        self.manufacturer = "Linak"
+        self.model = "KA20IC"
+        self.buttons = [
+            ("head_up", "Head Up"),
+            ("head_down", "Head Down"),
+            ("feet_up", "Feet Up"),
+            ("feet_down", "Feet Down"),
+            ("both_up", "Both Up"),
+            ("both_down", "Both Down"),
+        ]  # List of Tuples containing the MQTT payloads that should be registered to HA as buttons, and a human-friendly name
+
+        self.switches = [
+            ("light", "Bed Light")
+        ]  # List of Tuples containing the MQTT payloads for the switch and a friendly name
+
+        self.sensors = [
+            ("head_position", "%", "Head Position"),
+            ("foot_position", "%", "Feet Position"),
+        ]  # List of Tuples containing the MQTT topic for any sensors, the HA unit of measurement, and friendly name
+
+        self._connect_bed(ble)
 
     # Separate out the bed connection to an infinite loop that can
     # be called on init (or a communications failure).
-    def connectBed(self, ble):
+    def _connect_bed(self, ble):
         while True:
             try:
-                self.logger.debug("Attempting to connect to bed.")
-                self.device = ble.Peripheral(
-                    deviceAddr=self.addr,
-                    addrType="random"
-                )
-                self.print_characteristics()
+                self.logger.info("Attempting to connect to bed.")
+                self.device = ble.Peripheral(deviceAddr=self.addr, addrType="random")
+                self._print_characteristics()
                 self.logger.info("Connected to bed.")
                 self.logger.debug("Enabling bed control.")
-                self.device.readCharacteristic(0x000d)
+                self.device.readCharacteristic(0x000D)
                 self.logger.info("Bed control enabled.")
                 return
             except Exception:
@@ -55,12 +70,12 @@ class linakBLEController:
             self.logger.error("Error connecting to bed, retrying in one second.")
             time.sleep(1)
 
-    # Separate charWrite function.
-    def charWrite(self, cmd):
+    # Helper function to write command hex to BLE
+    def _write_char(self, cmd):
         self.logger.debug(f"Attempting to transmit command bytes: {cmd}")
         try:
             self.device.writeCharacteristic(
-                0x000e,
+                0x000E,
                 bytes.fromhex(cmd),
                 withResponse=False,
             )
@@ -69,25 +84,80 @@ class linakBLEController:
         self.logger.debug("Command sent successfully.")
         return
 
-    def sendCommand(self, name):
+    # Public function called by mqtt-bed.py when a command need to be sent over BLE
+    def send_command(self, name):
         cmd = self.commands.get(name, None)
         if cmd is None:
-            # print, but otherwise ignore Unknown Commands.
             self.logger.warning("Received unknown command... ignoring.")
-            return
-        self.charWriteInProgress = True
+            return {}
+
+        self.write_in_progress = True
         try:
-            self.charWrite(cmd)
-        except Exception as e:
+            self._write_char(cmd)
+            return self.update_state_based_on_command(name)
+        except Exception:
             self.logger.error("Error sending command, attempting reconnect.")
             start = time.time()
-            self.connectBed(ble)
+            self._connect_bed(ble)
             end = time.time()
             if (end - start) < 5:
                 try:
-                    self.charWrite(self, cmd)
+                    self._write_char(self, cmd)
                 except Exception:
-                    self.logger.error("Command failed to transmit despite second attempt, dropping command.")
+                    self.logger.error(
+                        "Command failed to transmit despite second attempt, dropping command."
+                    )
             else:
-                self.logger.warning("Bluetooth reconnect took more than five seconds, dropping command.")
-        self.charWriteInProgress = False
+                self.logger.warning(
+                    "Bluetooth reconnect took more than five seconds, dropping command."
+                )
+        finally:
+            self.write_in_progress = False
+
+    def toggle_light(self):
+        self.light_state = not self.light_state
+        self.send_command("Light")
+        return self.light_state
+
+    def update_state_based_on_command(self, command):
+        state = {}
+        match command:
+            case "head_up":
+                self.head_position = min(100, self.head_position + self.head_increment)
+                state["head_position"] = round(self.head_position, 2)
+            case "head_down":
+                self.head_position = max(0, self.head_position - self.head_increment)
+                state["head_position"] = round(self.head_position, 2)
+            case "feet_up":
+                self.feet_position = min(100, self.feet_position + self.feet_increment)
+                state["foot_position"] = round(self.head_position, 2)
+            case "feet_down":
+                self.feet_position = max(0, self.feet_position - self.feet_increment)
+                state["feet_position"] = round(self.head_position, 2)
+            case "both_down":
+                self.head_position = max(0, self.head_position - self.head_increment)
+                self.feet_position = max(0, self.feet_position - self.feet_increment)
+                state["head_position"] = round(self.head_position, 2)
+                state["feet_position"] = round(self.head_position, 2)
+            case "both_up":
+                self.head_position = min(100, self.head_position + self.head_increment)
+                self.feet_position = min(100, self.feet_position + self.feet_increment)
+                state["head_position"] = round(self.head_position, 2)
+                state["feet_position"] = round(self.head_position, 2)
+            case "light":
+                self.light_state = not self.light_state
+                state["light"] = "ON" if self.light_state else "OFF"
+
+        return state
+
+    def _print_characteristics(self):
+        try:
+            for service in self.device.getServices():
+                for chara in service.getCharacteristics():
+                    self.logger.debug("Characteristic UUID: %s" % chara.uuid)
+                    self.logger.debug("Handle: 0x%04x" % chara.getHandle())
+                    properties = chara.propertiesToString()
+                    self.logger.debug("Properties: %s" % properties)
+                    self.logger.debug(f"{'-'*58}")
+        except Exception as e:
+            self.logger.error("Error accessing characteristic: %s" % str(e))

--- a/controllers/serta.py
+++ b/controllers/serta.py
@@ -4,6 +4,8 @@ import pygatt
 class sertaBLEController:
     def __init__(self, addr):
         self.addr = addr
+        self.manufacturer = "Serta"
+        self.model = "Motion Perfect III"
         self.commands = {
             "Flat Preset": "e5fe1600000008fe",
             "ZeroG Preset": "e5fe1600100000f6",
@@ -23,7 +25,7 @@ class sertaBLEController:
         }
         self.adapter = pygatt.GATTToolBackend()
 
-    def sendCommand(self, name):
+    def send_command(self, name):
         cmd = self.commands.get(name, None)
         if cmd is None:
             raise Exception("Command not found: " + str(name))

--- a/mqtt-bed.py
+++ b/mqtt-bed.py
@@ -1,36 +1,41 @@
-#!/home/pi/.pyenv/shims/python
-
-import os
-import logging
-import asyncio
 import argparse
-import yaml
+import asyncio
+import json
+import logging
 from contextlib import AsyncExitStack
+
+import yaml
 from asyncio_mqtt import Client, MqttError
 
 from controllers.dewertokin import dewertokinBLEController
 from controllers.jiecang import jiecangBLEController
-from controllers.serta import sertaBLEController
 from controllers.linak import linakBLEController
+from controllers.serta import sertaBLEController
 
 # Load the YAML config
-with open('config.yaml', 'r') as file:
+with open("config.yaml", "r") as file:
     config = yaml.safe_load(file) or {}
 
-# Access the configuration variables set in config.yaml
-BED_ADDRESS = config.get('BED_ADDRESS', '00:00:00:00:00:00')
-BED_TYPE = config.get('BED_TYPE', 'serta')
-MQTT_USERNAME = config.get('MQTT_USERNAME', 'mqttbed')
-MQTT_PASSWORD = config.get('MQTT_PASSWORD', 'mqtt-bed')
-MQTT_SERVER = config.get('MQTT_SERVER', '127.0.0.1')
-MQTT_SERVER_PORT = config.get('MQTT_SERVER_PORT', 1883)
-MQTT_TOPIC = config.get('MQTT_TOPIC', 'bed')
-MQTT_CHECKIN_TOPIC = config.get('MQTT_CHECKIN_TOPIC', 'checkIn/bed')
-MQTT_CHECKIN_PAYLOAD = config.get('MQTT_CHECKIN_PAYLOAD', 'OK')
-MQTT_ONLINE_PAYLOAD = config.get('MQTT_ONLINE_PAYLOAD', 'online')
-MQTT_SHUTDOWN_PAYLOAD = config.get('MQTT_SHUTDOWN_PAYLOAD', 'shutdown')
-MQTT_QOS = config.get('MQTT_QOS', 0)
-RECONNECT_INTERVAL = config.get('RECONNECT_INTERVAL', 3)
+# DO NOT CHANGE VALUES HERE, CHANGE THEM IN config.yaml
+# Bed Settings ------------------------------------------------------------------
+BED_ADDRESS = config.get("BED_ADDRESS", "00:00:00:00:00:00")
+BED_TYPE = config.get("BED_TYPE", "serta")
+# MQTT Authorization ------------------------------------------------------------
+MQTT_USERNAME = config.get("MQTT_USERNAME", "mqttbed")
+MQTT_PASSWORD = config.get("MQTT_PASSWORD", "mqtt-bed")
+MQTT_SERVER = config.get("MQTT_SERVER", "127.0.0.1")
+MQTT_SERVER_PORT = config.get("MQTT_SERVER_PORT", 1883)
+# MQTT Topics & Payloads --------------------------------------------------------
+MQTT_BASE_TOPIC = config.get("MQTT_BASE_TOPIC", "bed")
+MQTT_AVAILABILITY_TOPIC = config.get("MQTT_AVAILABILITY_TOPIC", "availability")
+MQTT_AVAILABLE_PAYLOAD = config.get("MQTT_AVAILABLE_PAYLOAD", "online")
+MQTT_NOT_AVAILABLE_PAYLOAD = config.get("MQTT_NOT_AVAILABLE_PAYLOAD", "offline")
+MQTT_QOS = config.get("MQTT_QOS", 0)
+RECONNECT_INTERVAL = config.get("RECONNECT_INTERVAL", 3)
+# Auto Discovery ----------------------------------------------------------------
+MQTT_DISCOVERY = config.get("MQTT_DISCOVERY", True)
+MQTT_BED_NAME = config.get("MQTT_BED_NAME", "Smart Bed")
+MQTT_DISCOVERY_PREFIX = config.get("MQTT_DISCOVERY_PREFIX", "homeassistant")
 
 # Global variable to signal shutdown
 shutdown_signal = asyncio.Event()
@@ -53,46 +58,60 @@ async def bed_loop(ble):
         await stack.enter_async_context(client)
 
         # Set up the topic filter
-        manager = client.filtered_messages(MQTT_TOPIC)
+        manager = client.filtered_messages(MQTT_BASE_TOPIC)
         messages = await stack.enter_async_context(manager)
-        task = asyncio.create_task(bed_command(ble, messages))
+        task = asyncio.create_task(bed_command(ble, messages, client))
         tasks.add(task)
 
         try:
             # Subscribe to topic(s)
-            await client.subscribe(MQTT_TOPIC)
+            await client.subscribe(MQTT_BASE_TOPIC)
 
-            # let everyone know we are online
+            # Send HA MQTT Dicovery Topic message
+            if MQTT_DISCOVERY:
+                await publish_discovery_messages(ble, client)
+                await zero_sensors(ble, client)
+
+            # Start sending out hearbeats on the availability topic
             logger.info("Connected to MQTT")
-            await client.publish(MQTT_CHECKIN_TOPIC, MQTT_ONLINE_PAYLOAD, qos=1)
-
-            # let everyone know we are still alive
-            task = asyncio.create_task(
-                check_in(client, MQTT_CHECKIN_TOPIC, MQTT_CHECKIN_PAYLOAD)
+            tasks.add(
+                asyncio.create_task(
+                    check_in(client, MQTT_AVAILABILITY_TOPIC, MQTT_AVAILABLE_PAYLOAD)
+                )
             )
-            tasks.add(task)
 
-            # Wait for everything to complete (or fail due to, e.g., network
-            # errors)
+            # Wait for everything to complete (or fail due to, e.g., network errors)
             await asyncio.gather(*tasks)
         except asyncio.CancelledError:
             logger.debug("Shutdown signal received, closing MQTT connection")
             logger.info("Disconnecting from MQTT")
-            await client.publish(MQTT_CHECKIN_TOPIC, MQTT_SHUTDOWN_PAYLOAD, qos=1)
+            await client.publish(
+                MQTT_AVAILABILITY_TOPIC, MQTT_NOT_AVAILABLE_PAYLOAD, qos=1
+            )
             raise
 
 
 async def check_in(client, topic, payload):
     while True:
-        logger.debug(f'[topic="{topic}"] Publishing message={payload}')
+        logger.debug(f"[{MQTT_BASE_TOPIC}/{topic}] {payload}")
         await client.publish(topic, payload, qos=1)
         await asyncio.sleep(300)
 
 
-async def bed_command(ble, messages):
+async def bed_command(ble, messages, client):
     async for message in messages:
-        logger.debug(f'[topic_filter="{MQTT_TOPIC}"] {message.payload.decode()}')
-        ble.sendCommand(message.payload.decode())
+        command = message.payload.decode()
+        logger.debug(f"[{MQTT_BASE_TOPIC}] {command}")
+
+        # Send the command, and allow the controller to return a dictionary
+        # of states to be returned over MQTT
+        state = ble.send_command(message.payload.decode())
+
+        # Publish each state key-value pair to MQTT
+        if state:
+            for key, value in state.items():
+                logger.debug(f"Returned state: {value} publishing to bed/{key}/state")
+                await client.publish(f"bed/{key}/state", str(value), qos=1)
 
 
 async def cancel_tasks(tasks):
@@ -104,6 +123,69 @@ async def cancel_tasks(tasks):
             await task
         except asyncio.CancelledError:
             pass
+
+
+def create_discovery_payload(ble, entity, entity_type):
+    unique_id = f"{BED_TYPE}_bed_{entity[0].replace(' ', '_')}"
+    base_payload = {
+        "unique_id": unique_id,
+        "name": entity[1],
+        "device": {
+            "identifiers": [f"{BED_TYPE}_bed"],
+            "name": MQTT_BED_NAME,
+            "manufacturer": ble.manufacturer,
+            "model": ble.model,
+            "sw_version": "1.0.0",
+        },
+    }
+
+    match entity_type:
+        case "button":
+            base_payload.update(
+                {"command_topic": f"{MQTT_BASE_TOPIC}", "payload_press": entity[0]}
+            )
+        case "switch":
+            base_payload.update(
+                {
+                    "command_topic": f"{MQTT_BASE_TOPIC}/{entity[0]}/toggle",
+                    "state_topic": f"{MQTT_BASE_TOPIC}/{entity[0]}/state",
+                    "payload": f"{entity[0]}",
+                }
+            )
+        case "sensor":
+            base_payload.update(
+                {
+                    "name": entity[2],
+                    "state_topic": f"{MQTT_BASE_TOPIC}/{entity[0]}/state",
+                    "unit_of_measurement": entity[1],
+                }
+            )
+
+    return json.dumps(base_payload)
+
+
+async def publish_discovery_messages(ble, client):
+    entity_types = {
+        "button": getattr(ble, "buttons", []),
+        "switch": getattr(ble, "switches", []),
+        "sensor": getattr(ble, "sensors", []),
+    }
+
+    for entity_type, entities in entity_types.items():
+        logger.debug(f"{entity_type.capitalize()} Discovery Payloads {'-'*80}")
+        for entity in entities:
+            topic = f"{MQTT_DISCOVERY_PREFIX}/{entity_type}/{BED_TYPE}_bed/{entity[0]}/config"
+            payload = create_discovery_payload(ble, entity, entity_type)
+            logger.debug(f"{topic} -- {payload}")
+            await client.publish(topic, payload, qos=1, retain=True)
+
+
+async def zero_sensors(ble, client):
+    if hasattr(ble, "sensors"):
+        for sensor in ble.sensors:
+            state_topic = f"{MQTT_BASE_TOPIC}/{sensor[0]}/state"
+            initial_value = "0"
+            await client.publish(state_topic, initial_value, qos=1, retain=True)
 
 
 async def main():
@@ -124,7 +206,9 @@ async def main():
             try:
                 await bed_loop(ble)
             except MqttError as error:
-                logger.error(f'Error "{error}". Reconnecting in {RECONNECT_INTERVAL} seconds.')
+                logger.error(
+                    f'Error "{error}". Reconnecting in {RECONNECT_INTERVAL} seconds.'
+                )
             finally:
                 await asyncio.sleep(RECONNECT_INTERVAL)
     except KeyboardInterrupt:
@@ -137,19 +221,27 @@ async def main():
 
         await asyncio.gather(*tasks, return_exceptions=True)
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='BLE adjustable bed control over MQTT')
-    parser.add_argument('--log', dest='log_level', default='INFO',
-                        help='Set the log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)')
+    parser = argparse.ArgumentParser(description="BLE adjustable bed control over MQTT")
+    parser.add_argument(
+        "--log",
+        dest="log_level",
+        default="INFO",
+        help="Set the log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+    )
 
     args = parser.parse_args()
 
     numeric_level = getattr(logging, args.log_level.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {args.log_level}')
+        raise ValueError(f"Invalid log level: {args.log_level}")
 
-    logging.basicConfig(level=numeric_level, format='%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s',
-                        datefmt='%H:%M:%S')
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s",
+        datefmt="%H:%M:%S",
+    )
     logger = logging.getLogger(__name__)
 
     # Run the main program

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "MQTT control for adjustable beds using Bluetooth"
 authors = ["Denny Reiter <denny@reiters.org>", "Aaron Vigal <admin@aaronvigal.com>", "Joshua <Final-Hawk>", "mishnz"]
 
 [tool.poetry.dependencies]
-python = "^3.9.1"
+python = "^3.10"
 paho-mqtt = "^1.5.1"
 asyncio-mqtt = "^0.8.0"
 enum-compat = "^0.0.3"
@@ -21,7 +21,7 @@ name = "mqtt-bed"
 version = "1.0.0"
 description = "MQTT control for adjustable beds using Bluetooth"
 dependencies = [
-    "python >= 3.9.1",
+    "python >= 3.10",
     "paho-mqtt==1.5.1",
     "asyncio-mqtt==0.8.0",
     "enum-compat==0.0.3",


### PR DESCRIPTION
Added the ability for controllers to specify their own buttons, switches, and sensors. This information gets crafted into MQTT Discovery payloads to automatically register your device in Home Assistant, if enabled in `config.yaml`.

This does not break any existing bed controller integrations, but integrations will need to be updated if they want to support MQTT Discovery. 