### PR TITLE
 Add Support for DerwentOkin Old BLE Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A project to enable MQTT control for BLE adjustable beds. Currently supported ad
 - Serta adjustable beds with Bluetooth, like the [Serta Motion Perfect III](https://www.serta.com/sites/ssb/serta.com/uploads/2016/adjustable-foundations/MotionPerfectIII_Manual_V004_04142016.pdf)
 - 'Glide' with the jiecang BLUE controller (Dream Motion app)
 - 'A H Beard' with the DerwentOkin BLE controller ("Comfort Enhancement 2" aka "Comfort Plus" app)
+- 'HankookGallery' with the DerwentOkin BLE controller [OKIN Comfort Bed app](https://apps.apple.com/kr/app/okin-comfort-bed/id1149710773) - (It maybe old version of 'Compfort Plus' app)
 - Linak KA20IC with the "Bed Control" app
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@
 BED_ADDRESS: "00:00:00:00:00:00"
 
 # Bed controller type, supported values are
-# "serta", "jiecang", "dewertokin", and "linak"
+# "serta", "jiecang", "dewertokin", "dewertokin_old", and "linak"
 BED_TYPE: serta
 
 # MQTT credentials

--- a/controllers/dewertokin_old.py
+++ b/controllers/dewertokin_old.py
@@ -1,0 +1,42 @@
+from .dewertokin import dewertokinBLEController
+import logging
+import threading
+import time
+
+import bluepy.btle as ble
+
+
+class dewertokinOldBLEController(dewertokinBLEController):
+    def __init__(self, addr):
+        self.logger = logging.getLogger(__name__)
+        self.charWriteInProgress = False
+        self.addr = addr
+        self.manufacturer = "DerwentOkin"
+        self.model = "HankookGallery"
+        self.commands = {
+            "Flat Preset": "E5FE 1601 0000 0203",
+            "ZeroG Preset": "E5FE 1601 0000 0104",
+            "Memory 1": "E5FE 1601 0000 08FD",
+            "Memory 2": "E5FE 1601 0000 09FC",
+        }
+        # Initialise the adapter and connect to the bed before we start waiting for messages.
+        self.connectBed(ble)
+
+
+    # Separate out the bed connection to an infinite loop that can be called on init (or a communications failure).
+    def connectBed(self, ble):
+        while True:
+            try:
+                self.logger.debug("Attempting to connect to bed.")
+                # self.device = ble.Peripheral(deviceAddr=self.addr, addrType="random")
+                self.device = ble.Peripheral(deviceAddr=self.addr, addrType='public', iface = 0)
+                self.logger.info("Connected to bed.")
+                self.logger.debug("Enabling bed control.")
+                self.device.readCharacteristic(0x001E)
+                self.device.readCharacteristic(0x0020)
+                self.logger.info("Bed control enabled.")
+                return
+            except Exception:
+                pass
+            self.logger.error("Error connecting to bed, retrying in one second.")
+            time.sleep(1)

--- a/mqtt-bed.py
+++ b/mqtt-bed.py
@@ -9,6 +9,7 @@ import yaml
 from asyncio_mqtt import Client, MqttError
 
 from controllers.dewertokin import dewertokinBLEController
+from controllers.dewertokin_old import dewertokinOldBLEController
 from controllers.jiecang import jiecangBLEController
 from controllers.linak import linakBLEController
 from controllers.serta import sertaBLEController
@@ -206,6 +207,8 @@ async def main():
         ble = jiecangBLEController(BED_ADDRESS)
     elif BED_TYPE == "dewertokin":
         ble = dewertokinBLEController(BED_ADDRESS)
+    elif BED_TYPE == "dewertokin_old":
+        ble = dewertokinOldBLEController(BED_ADDRESS)
     elif BED_TYPE == "linak":
         ble = linakBLEController(BED_ADDRESS)
     else:


### PR DESCRIPTION
This merge request adds support for the DerwentOkin Old BLE controller for the OKIN utilized bed used by HankookGallery. 

When using repository, the command of dewertokinBLEController did not work. 
I assumed that the command was different
So I intercepted the bluetooth packet from OKIN Comfort Bed app([OKIN Comfort Bed app](https://apps.apple.com/kr/app/okin-comfort-bed/id1149710773) - (It maybe old version of 'Comfort Plus' app)) and created dewertokin_old type with that content.